### PR TITLE
fix devcontainer go version to 1.19

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:0-1.18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:0-1.19-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
Updates go version to 1.19 for devcontainer 